### PR TITLE
hub should error out on errors

### DIFF
--- a/cmd/hub/cmd/build.go
+++ b/cmd/hub/cmd/build.go
@@ -96,7 +96,7 @@ func runBuild(opts *buildOptions) error {
 		})
 		if err != nil {
 			log.Error(err.Error())
-			return nil
+			return err
 		}
 	}
 


### PR DESCRIPTION
## Description

As [noted by @cprivitere](https://github.com/tinkerbell/hub/issues/69#issuecomment-1010156166)
> The go code that pushes the image doesn't properly pass the error back up the stack. So it looks like the build and push succeeded in GitHub actions when it actually failed.

This change surfaces that error.

## Why is this needed

Silent failure is bad.

## How Has This Been Tested?

A CI build for #87 failed properly when I added this change.

## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
