### PR TITLE
Fix blank spaces between partitions

### DIFF
--- a/actions/rootio/v1/pkg/storage/partition.go
+++ b/actions/rootio/v1/pkg/storage/partition.go
@@ -90,7 +90,7 @@ func Partition(d types.Disk) error {
 				End:   sectorEnd,
 			}
 
-			sectorStart += sectorEnd
+			sectorStart = sectorEnd + 1
 
 			switch d.Partitions[x].Label {
 			case "SWAP":


### PR DESCRIPTION
## Description

Fix huge blank spaces between partitions

## Why is this needed

rootio partition leaves huge blank spaces between partitions

Fixes: #98


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
