### PR TITLE
[CEXEC] Code clean up; Add resolv.conf fixing in chroot:

### DIFF
--- a/cexec/README.md
+++ b/cexec/README.md
@@ -49,7 +49,7 @@ CLI flags take precedence over environment variables, which take precedence over
 |--------------|------|------|---------------|----------|-------------|
 | `BLOCK_DEVICE` | `--block-device` | string | "" | yes | The block device to mount. |
 | `FS_TYPE` | `--fs-type` | string | "" | yes | The filesystem type of the block device. |
-| `CHROOT` | `--chroot` | string | "" | no | If set to `y` (or a non empty string), the Action will execute the given command within a chroot environment. This option is DEPRECATED. Future versions will always chroot |
+| `CHROOT` | `--chroot` | string | "" | no | If set to `y` (or a non empty string), the Action will execute the given command within a chroot environment. This option is DEPRECATED. Future versions will always chroot. |
 | `CMD_LINE` | `--cmd-line` | string | "" | yes | The command to execute. |
 | `DEFAULT_INTERPRETER` | `--default-interpreter` | string | "" | no | The default interpreter to use when executing commands. This is useful when you need to execute multiple commands. |
 | `UPDATE_RESOLV_CONF` | `--update-resolv-conf` | boolean | false | no | If set to `true`, the cexec Action will update the `/etc/resolv.conf` file within the chroot environment with the `/etc/resolv.conf` from the host. |

--- a/cexec/README.md
+++ b/cexec/README.md
@@ -57,3 +57,14 @@ CLI flags take precedence over environment variables, which take precedence over
 
 Any environment variables you set on the Action will be available to the command you execute.
 For example, if you set `DEBIAN_FRONTEND: noninteractive` as an environment variable, it will be available to the command you execute.
+
+### Exit codes
+
+The following exit codes or statuses are returned by the `cexec` Action:
+
+| Code | Description |
+|------|-------------|
+| 0 | The cexec Action was executed successfully. |
+| 10 | The was a failure parsing cli flags and/or env variables. |
+| 20 | Required cli flags and/or env variables were not specified. |
+| 30 | The cexec Action failed to execute successfully. |

--- a/cexec/README.md
+++ b/cexec/README.md
@@ -2,10 +2,12 @@
 quay.io/tinkerbell/actions/cexec:latest
 ```
 
-The `cexec` action performs *execution* either within a [chroot](https://en.wikipedia.org/wiki/Chroot) environment
+The `cexec` Action performs *execution* either within a [chroot](https://en.wikipedia.org/wiki/Chroot) environment
 or within the base filesystem. The primary use-case is being able to provision
 files/an Operating System to disk and then being able to execute something that
 perhaps resides within that filesystem.
+
+## Examples
 
 ```yaml
 actions:
@@ -19,7 +21,7 @@ actions:
       CMD_LINE: "grub-install --root-directory=/boot /dev/sda"
 ```
 
-In order to execute multiple commands (seperated by a semi-colon) we will
+In order to execute multiple commands (separated by a semi-colon) we will
 need to leverage a shell. We do this by passing `sh -c` as a `DEFAULT_INTERPRETER`.
 This interpreter will then parse your commands.
 
@@ -34,4 +36,24 @@ actions:
       CHROOT: y
       DEFAULT_INTERPRETER: "/bin/sh -c"
       CMD_LINE: "apt-get -y update; apt-get -y upgrade"
+      UPDATE_RESOLV_CONF: true
+      DEBIAN_FRONTEND: noninteractive
 ```
+
+### Environment variables and CLI flags
+
+All options can be set either via environment variables or CLI flags.
+CLI flags take precedence over environment variables, which take precedence over default values.
+
+| Env variable | Flag | Type | Default Value | Required | Description |
+|--------------|------|------|---------------|----------|-------------|
+| `BLOCK_DEVICE` | `--block-device` | string | "" | yes | The block device to mount. |
+| `FS_TYPE` | `--fs-type` | string | "" | yes | The filesystem type of the block device. |
+| `CHROOT` | `--chroot` | string | "" | no | If set to `y` (or a non empty string), the Action will execute the given command within a chroot environment. This option is DEPRECATED. Future versions will always chroot |
+| `CMD_LINE` | `--cmd-line` | string | "" | yes | The command to execute. |
+| `DEFAULT_INTERPRETER` | `--default-interpreter` | string | "" | no | The default interpreter to use when executing commands. This is useful when you need to execute multiple commands. |
+| `UPDATE_RESOLV_CONF` | `--update-resolv-conf` | boolean | false | no| If set to `true`, the cexec Action will update the `/etc/resolv.conf` file within the chroot environment with the `/etc/resolv.conf` from the host. |
+| `JSON_OUTPUT` | `--json-output` | boolean | true | no | If set to `true`, the cexec Action will log output in JSON format. The defaults to `true`. If set to `false`, the cexec Action will log output in plain text format. |
+
+Any environment variables you set on the Action will be available to the command you execute.
+For example, if you set `DEBIAN_FRONTEND: noninteractive` as an environment variable, it will be available to the command you execute.

--- a/cexec/README.md
+++ b/cexec/README.md
@@ -52,7 +52,7 @@ CLI flags take precedence over environment variables, which take precedence over
 | `CHROOT` | `--chroot` | string | "" | no | If set to `y` (or a non empty string), the Action will execute the given command within a chroot environment. This option is DEPRECATED. Future versions will always chroot |
 | `CMD_LINE` | `--cmd-line` | string | "" | yes | The command to execute. |
 | `DEFAULT_INTERPRETER` | `--default-interpreter` | string | "" | no | The default interpreter to use when executing commands. This is useful when you need to execute multiple commands. |
-| `UPDATE_RESOLV_CONF` | `--update-resolv-conf` | boolean | false | no| If set to `true`, the cexec Action will update the `/etc/resolv.conf` file within the chroot environment with the `/etc/resolv.conf` from the host. |
+| `UPDATE_RESOLV_CONF` | `--update-resolv-conf` | boolean | false | no | If set to `true`, the cexec Action will update the `/etc/resolv.conf` file within the chroot environment with the `/etc/resolv.conf` from the host. |
 | `JSON_OUTPUT` | `--json-output` | boolean | true | no | If set to `true`, the cexec Action will log output in JSON format. The defaults to `true`. If set to `false`, the cexec Action will log output in plain text format. |
 
 Any environment variables you set on the Action will be available to the command you execute.

--- a/cexec/main.go
+++ b/cexec/main.go
@@ -126,10 +126,10 @@ func (s settings) cexec(ctx context.Context, log *slog.Logger) error {
 				}()
 				// create an empty resolv.conf in the chroot so that it can be bind mounted
 				if _, err := os.Create(resolv); err != nil {
-					log.Info("error creating resolv.conf, resolv.conf will not work in the chroot", "error", err)
+					return fmt.Errorf("error creating resolv.conf, resolv.conf will not work in the chroot: %w", err)
 				}
 			} else {
-				log.Info("error backing up resolv.conf, resolv.conf will not work in the chroot", "error", err)
+				return fmt.Errorf("error backing up resolv.conf, resolv.conf will not work in the chroot: %w", err)
 			}
 		}
 

--- a/cexec/main.go
+++ b/cexec/main.go
@@ -47,7 +47,7 @@ func main() {
 
 	if err := ff.Parse(fs, os.Args[1:], ff.WithEnvVarNoPrefix()); err != nil {
 		logger.Error(err.Error())
-		os.Exit(1)
+		os.Exit(10)
 	}
 
 	// check for required fields to be set.
@@ -55,7 +55,7 @@ func main() {
 		fmt.Fprintln(os.Stderr, "missing required fields", missingFields)
 		fmt.Fprintln(os.Stderr)
 		fs.Usage()
-		os.Exit(10)
+		os.Exit(20)
 	}
 
 	// TODO(jacobweinstock): add field validations for the settings struct.
@@ -76,7 +76,7 @@ func main() {
 
 	if err := s.cexec(ctx, logger); err != nil {
 		logger.ErrorContext(ctx, err.Error())
-		os.Exit(20)
+		os.Exit(30)
 	}
 }
 

--- a/cexec/main.go
+++ b/cexec/main.go
@@ -1,111 +1,202 @@
 package main
 
 import (
+	"context"
+	"errors"
+	"flag"
 	"fmt"
+	"log/slog"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"syscall"
 
-	log "github.com/sirupsen/logrus"
+	"github.com/peterbourgon/ff/v3"
 )
 
-const mountAction = "/mountAction"
+const (
+	mountAction = "/mountAction"
+	envPrefix   = "CEXEC"
+)
+
+type settings struct {
+	blockDevice        string
+	filesystemType     string
+	chroot             string
+	defaultInterpreter string
+	cmdLine            string
+	updateResolvConf   bool
+}
 
 func main() {
-	fmt.Printf("CEXEC - Chroot Exec\n------------------------\n")
+	ctx, done := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGHUP, syscall.SIGTERM)
+	defer done()
 
-	// Parse the environment variables that are passed into the action
-	blockDevice := os.Getenv("BLOCK_DEVICE")
-	filesystemType := os.Getenv("FS_TYPE")
-	chroot := os.Getenv("CHROOT")
-	defaultInterpreter := os.Getenv("DEFAULT_INTERPRETER")
-	cmdLine := os.Getenv("CMD_LINE")
+	logger := slog.New(slog.NewTextHandler(os.Stdout, nil))
+	fs := flag.NewFlagSet("cexec", flag.ExitOnError)
+	s := settings{}
+	fs.StringVar(&s.blockDevice, "block-device", "", "block device to mount (required)")
+	fs.StringVar(&s.filesystemType, "fs-type", "", "filesystem type (required)")
+	fs.StringVar(&s.chroot, "chroot", "", "use chroot environment to run given command (deprecated)")
+	fs.StringVar(&s.defaultInterpreter, "default-interpreter", "", "default interpreter (optional)")
+	fs.StringVar(&s.cmdLine, "cmd-line", "", "command line to execute (required)")
+	fs.BoolVar(&s.updateResolvConf, "update-resolv-conf", false, "update /etc/resolv.conf in chroot environment (optional)")
+	jsonLogger := fs.Bool("json-outout", true, "enable json output for logging")
 
-	var exitChroot func() error
+	if err := ff.Parse(fs, os.Args[1:], ff.WithEnvVarNoPrefix()); err != nil {
+		logger.Error(err.Error())
+		os.Exit(1)
+	}
 
-	if blockDevice == "" {
-		log.Fatalf("No Block Device speified with Environment Variable [BLOCK_DEVICE]")
+	// check for required fields to be set.
+	if missingFields := s.checkRequiredFields(); len(missingFields) > 0 {
+		fmt.Fprintln(os.Stderr, "missing required fields", missingFields)
+		fmt.Fprintln(os.Stderr)
+		fs.Usage()
+		os.Exit(10)
+	}
+
+	// TODO(jacobweinstock): add field validations for the settings struct.
+
+	if *jsonLogger {
+		logger = slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	}
+
+	logger.Info("debugging",
+		"block-device", s.blockDevice,
+		"fs-type", s.filesystemType,
+		"chroot", s.chroot,
+		"default-interpreter", s.defaultInterpreter,
+		"cmd-line", s.cmdLine,
+		"json-output", *jsonLogger,
+		"update-resolv-conf", s.updateResolvConf,
+	)
+
+	if err := s.cexec(ctx, logger); err != nil {
+		logger.ErrorContext(ctx, err.Error())
+		os.Exit(20)
+	}
+}
+
+func (s settings) checkRequiredFields() []string {
+	var missingFields []string
+	if s.blockDevice == "" {
+		missingFields = append(missingFields, "block-device")
+	}
+	if s.filesystemType == "" {
+		missingFields = append(missingFields, "fs-type")
+	}
+	if s.cmdLine == "" {
+		missingFields = append(missingFields, "cmd-line")
+	}
+	return missingFields
+}
+
+func (s settings) cexec(ctx context.Context, log *slog.Logger) error {
+	log.Info("CEXEC - Chroot Exec")
+
+	if s.blockDevice == "" {
+		return errors.New("no Block Device speified with Environment Variable [BLOCK_DEVICE]")
 	}
 
 	// Create the /mountAction mountpoint (no folders exist previously in scratch container)
-	err := os.Mkdir(mountAction, os.ModeDir)
-	if err != nil {
-		log.Fatalf("Error creating the action Mountpoint [%s]", mountAction)
+	if err := os.Mkdir(mountAction, os.ModeDir); err != nil {
+		return fmt.Errorf("error creating the mount point [%s], error: %w", mountAction, err)
 	}
 
 	// Mount the block device to the /mountAction point
-	err = syscall.Mount(blockDevice, mountAction, filesystemType, 0, "")
-	if err != nil {
-		log.Fatalf("Mounting [%s] -> [%s] error [%v]", blockDevice, mountAction, err)
+	if err := syscall.Mount(s.blockDevice, mountAction, s.filesystemType, 0, ""); err != nil {
+		return fmt.Errorf("error mounting [%s] -> [%s], error: %v", s.blockDevice, mountAction, err)
 	}
-	log.Infof("Mounted [%s] -> [%s]", blockDevice, mountAction)
+	log.Info("mounted device successfully", "source", s.blockDevice, "destination", mountAction)
 
-	if chroot != "" {
-		err = MountSpecialDirs()
-		if err != nil {
-			log.Fatal(err)
+	var exitChroot func() error
+	if s.chroot != "" {
+		if s.updateResolvConf {
+			// fix resolv.conf as it normally doesn't work in chroot
+			// backup the original resolv.conf
+			resolv := filepath.Join(mountAction, "etc", "resolv.conf")
+			if err := backupFile(resolv); err == nil {
+				defer func() {
+					// restore the original resolv.conf
+					if err := restoreFile(resolv); err != nil {
+						log.Error("unable to restore resolv.conf", "error", err)
+					}
+				}()
+				// create an empty resolv.conf in the chroot so that it can be bind mounted
+				if _, err := os.Create(resolv); err != nil {
+					log.Info("error creating resolv.conf, resolv.conf will not work in the chroot", "error", err)
+				}
+			} else {
+				log.Info("error backing up resolv.conf, resolv.conf will not work in the chroot", "error", err)
+			}
 		}
-		log.Infoln("Changing root before executing command")
-		exitChroot, err = Chroot(mountAction)
+
+		if err := s.mountSpecialDirs(); err != nil {
+			return err
+		}
+		defer s.umountSpecialDirs()
+		log.Info("Changing root before executing command")
+		var err error
+		exitChroot, err = chroot(mountAction)
 		if err != nil {
-			log.Fatalf("Error changing root to [%s]", mountAction)
+			return fmt.Errorf("error changing root to [%s], error: %w", mountAction, err)
 		}
 	}
 
-	if defaultInterpreter != "" {
+	if s.defaultInterpreter != "" {
 		// Split the interpreter by space, in the event that the default intprepretter has flags.
-		di := strings.Split(defaultInterpreter, " ")
+		di := strings.Split(s.defaultInterpreter, " ")
 		if len(di) == 0 {
-			log.Fatalf("Error parsing [\"DEFAULT_INTERPETER\"] [%s]\n", defaultInterpreter)
+			return fmt.Errorf("error parsing [\"DEFAULT_INTERPRETER\"] [%s]", s.defaultInterpreter)
 		}
 		// Look for default shell intepreter
-		_, err = os.Stat(di[0])
-		if os.IsNotExist(err) {
-			log.Fatalf("Unable to find the [\"DEFAULT_INTERPETER\"] [%s], check chroot and interpreter path", defaultInterpreter)
+		if _, err := os.Stat(di[0]); os.IsNotExist(err) {
+			return fmt.Errorf("unable to find the [\"DEFAULT_INTERPRETER\"] [%s], check chroot and interpreter path", s.defaultInterpreter)
 		}
-		di = append(di, cmdLine)
+		di = append(di, s.cmdLine)
 		cmd := exec.Command(di[0], di[1:]...)
 		cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 		debugCMD := fmt.Sprintf("%s %v", di[0], di[1:])
-		err = cmd.Start()
-		if err != nil {
-			log.Fatalf("Error starting [%s] [%v]", debugCMD, err)
+		if err := cmd.Start(); err != nil {
+			return fmt.Errorf("error starting [%s] [%w]", debugCMD, err)
 		}
-		err = cmd.Wait()
-		if err != nil {
-			log.Fatalf("Error running [%s] [%v]", debugCMD, err)
+		if err := cmd.Wait(); err != nil {
+			return fmt.Errorf("error running [%s] [%w]", debugCMD, err)
 		}
 	} else {
 		// Format the cmdLine string into separate execution tasks
-		commandLines := strings.Split(cmdLine, ";")
+		commandLines := strings.Split(s.cmdLine, ";")
 		for x := range commandLines {
 			command := strings.Split(commandLines[x], " ")
 			cmd := exec.Command(command[0], command[1:]...)
 			cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
 			debugCMD := fmt.Sprintf("%s %v", command[0], command[1:])
-			err = cmd.Start()
-			if err != nil {
-				log.Fatalf("Error starting [%s] [%v]", debugCMD, err)
+			if err := cmd.Start(); err != nil {
+				return fmt.Errorf("error starting [%s] [%w]", debugCMD, err)
 			}
-			err = cmd.Wait()
-			if err != nil {
-				log.Fatalf("Error running [%s] [%v]", debugCMD, err)
+			if err := cmd.Wait(); err != nil {
+				return fmt.Errorf("error running [%s] [%w]", debugCMD, err)
 			}
 		}
 	}
 
-	if chroot != "" {
-		err = exitChroot()
-		if err != nil {
-			log.Errorf("Error exiting root from [%s], execution continuing", mountAction)
+	if s.chroot != "" {
+		if err := exitChroot(); err != nil {
+			log.Info("error exiting chroot, execution continuing", "chrootMountPoint", mountAction, "error", err)
+		}
+		if err := s.umountSpecialDirs(); err != nil {
+			log.Error("error unmounting special directories", "error", err)
 		}
 	}
+
+	return nil
 }
 
-// Chroot handles changing the root, and returning a function to return back to the present directory.
-func Chroot(path string) (func() error, error) {
+// chroot handles changing the root, and returning a function to return back to the present directory.
+func chroot(path string) (func() error, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return nil, err
@@ -135,28 +226,77 @@ func Chroot(path string) (func() error, error) {
 	}, nil
 }
 
-// MountSpecialDirs ensures that /dev /proc /sys exist in the chroot.
-func MountSpecialDirs() error {
+// mountSpecialDirs ensures that /dev /proc /sys /etc/resolv.conf exist in the chroot.
+func (s settings) mountSpecialDirs() error {
 	// Mount dev
 	dev := filepath.Join(mountAction, "dev")
-
 	if err := syscall.Mount("none", dev, "devtmpfs", syscall.MS_RDONLY, ""); err != nil {
 		return fmt.Errorf("couldn't mount /dev to %v: %w", dev, err)
 	}
 
 	// Mount proc
 	proc := filepath.Join(mountAction, "proc")
-
 	if err := syscall.Mount("none", proc, "proc", syscall.MS_RDONLY, ""); err != nil {
 		return fmt.Errorf("couldn't mount /proc to %v: %w", proc, err)
 	}
 
 	// Mount sys
 	sys := filepath.Join(mountAction, "sys")
-
 	if err := syscall.Mount("none", sys, "sysfs", syscall.MS_RDONLY, ""); err != nil {
 		return fmt.Errorf("couldn't mount /sys to %v: %w", sys, err)
 	}
 
+	if s.updateResolvConf {
+		// Mount /etc/resolv.conf
+		resolv := filepath.Join(mountAction, "etc/resolv.conf")
+		if err := syscall.Mount("/etc/resolv.conf", resolv, "", syscall.MS_BIND|syscall.MS_RDONLY, ""); err != nil {
+			return fmt.Errorf("couldn't mount /etc/resolv.conf to %v: %w", resolv, err)
+		}
+	}
+
+	return nil
+}
+
+func (s settings) umountSpecialDirs() error {
+	// Unmount dev
+	dev := filepath.Join(mountAction, "dev")
+	if err := syscall.Unmount(dev, 0); err != nil {
+		return fmt.Errorf("couldn't unmount %v: %w", dev, err)
+	}
+
+	// Unmount proc
+	proc := filepath.Join(mountAction, "proc")
+	if err := syscall.Unmount(proc, 0); err != nil {
+		return fmt.Errorf("couldn't unmount %v: %w", proc, err)
+	}
+
+	// Unmount sys
+	sys := filepath.Join(mountAction, "sys")
+	if err := syscall.Unmount(sys, 0); err != nil {
+		return fmt.Errorf("couldn't unmount %v: %w", sys, err)
+	}
+
+	if s.updateResolvConf {
+		// Unmount /etc/resolv.conf
+		resolv := filepath.Join(mountAction, "etc/resolv.conf")
+		if err := syscall.Unmount(resolv, 0); err != nil {
+			return fmt.Errorf("couldn't unmount %v: %w", resolv, err)
+		}
+	}
+
+	return nil
+}
+
+func backupFile(file string) error {
+	if err := os.Rename(file, file+".backup"); err != nil {
+		return fmt.Errorf("error backing up %v: %w", file, err)
+	}
+	return nil
+}
+
+func restoreFile(file string) error {
+	if err := os.Rename(file+".backup", file); err != nil {
+		return fmt.Errorf("error restoring %v: %w", file, err)
+	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dustin/go-humanize v1.0.0
 	github.com/klauspost/compress v1.17.7
 	github.com/opencontainers/go-digest v1.0.0
+	github.com/peterbourgon/ff/v3 v3.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/spf13/cobra v1.1.3

--- a/go.sum
+++ b/go.sum
@@ -221,6 +221,8 @@ github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59P
 github.com/opencontainers/runtime-spec v1.0.2/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
+github.com/peterbourgon/ff/v3 v3.4.0 h1:QBvM/rizZM1cB0p0lGMdmR7HxZeI/ZrBWB4DqLkMUBc=
+github.com/peterbourgon/ff/v3 v3.4.0/go.mod h1:zjJVUhx+twciwfDl0zBcFzl4dW8axCRyXE/eKY9RztQ=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2 h1:JhzVVoYvbOACxoUmOs6V/G4D5nPVUW73rKvXxP4XUJc=
 github.com/phayes/freeport v0.0.0-20180830031419-95f893ade6f2/go.mod h1:iIss55rKnNBTvrwdmkUpLnDpZoAHvWaiq5+iMmen4AE=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Cleaning up the code base for improved maintainability. Add option to use the host's /etc/resolv.conf in the chroot env. This resolves issues with DNS based network calls for things like package managers, etc.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #92 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
