### PR TITLE
Fixing the issue that mkfs.xfs was not added to the base image

### DIFF
--- a/rootio/Dockerfile
+++ b/rootio/Dockerfile
@@ -39,6 +39,9 @@ RUN make LDFLAGS="--static"
 FROM alpine:3.18 as lvm
 RUN apk update && apk add lvm2-static=2.03.21-r3
 
+FROM alpine:3.18 AS xfs
+RUN apk update && apk add xfsprogs
+
 # Build final image
 FROM scratch
 COPY --from=mke2fs /e2fsprogs-1.45.6/misc/mke2fs.static /sbin/mke2fs
@@ -47,4 +50,9 @@ COPY --from=swap util-linux/mkswap /sbin/mkswap
 COPY --from=fattools dosfstools/src/mkfs.fat /sbin/mkfs.fat
 COPY --from=lvm /usr/sbin/lvm.static /sbin/lvm
 COPY --from=rootio /src/rootio/rootio /usr/bin/rootio
+COPY --from=xfs /sbin/mkfs.xfs /sbin/mkfs.xfs
+COPY --from=xfs /sbin/fsck.xfs /sbin/fsck.xfs
+COPY --from=xfs /sbin/xfs_repair /sbin/xfs_repair
+COPY --from=xfs /lib /lib
+COPY --from=xfs /usr/lib /usr/lib
 ENTRYPOINT ["/usr/bin/rootio"]


### PR DESCRIPTION
## Description

Added mkfs.xfs support to the base image

## Why is this needed
To be able to create xfs partition
https://github.com/tinkerbell/actions/issues/131

Fixes: #
copy to the image the mkfs.xfs command with all libs
## How Has This Been Tested?

1. created partition with format of xfs
2. set action as rootio and run the installation
3. checked that new partition was created with format of xfs

## How are existing users impacted? What migration steps/scripts do we need?

Fixes a bug

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
