### PR TITLE
Fix Docker build warning:

### DIFF
--- a/archive2disk/Dockerfile
+++ b/archive2disk/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.21-alpine as archive2disk
+FROM golang:1.21-alpine AS archive2disk
 RUN apk add --no-cache git ca-certificates gcc musl-dev
 COPY . /src
 WORKDIR /src/archive2disk

--- a/cexec/Dockerfile
+++ b/cexec/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.21-alpine as cexec
+FROM golang:1.21-alpine AS cexec
 RUN apk add --no-cache git ca-certificates gcc linux-headers musl-dev
 COPY . /src
 WORKDIR /src/cexec

--- a/image2disk/Dockerfile
+++ b/image2disk/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.21-alpine as image2disk
+FROM golang:1.21-alpine AS image2disk
 RUN apk add --no-cache git ca-certificates gcc linux-headers musl-dev
 COPY . /src
 WORKDIR /src/image2disk

--- a/kexec/Dockerfile
+++ b/kexec/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.21-alpine as kexec
+FROM golang:1.21-alpine AS kexec
 RUN apk add --no-cache git ca-certificates gcc linux-headers musl-dev
 COPY . /src
 WORKDIR /src/kexec

--- a/oci2disk/Dockerfile
+++ b/oci2disk/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.21-alpine as oci2disk
+FROM golang:1.21-alpine AS oci2disk
 RUN apk add --no-cache git ca-certificates gcc linux-headers musl-dev
 COPY . /src
 WORKDIR /src/oci2disk

--- a/qemuimg2disk/Dockerfile
+++ b/qemuimg2disk/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM alpine:3.13 as builder
+FROM alpine:3.13 AS builder
 ENV QEMU_NAME="qemu"
 ARG QEMU_REV="6.1.0"
 ENV QEMU_SRC_BASENAME="${QEMU_NAME}-${QEMU_REV}"
@@ -40,14 +40,14 @@ RUN sed -e 's|-lbrotlidec|-lbrotlicommon-static -lbrotlidec-static -lbrotlienc-s
 RUN make -j$(nproc) qemu-img
 RUN cp build/qemu-img /bin/qemu-img
 
-FROM golang:1.21-alpine as qemuimg2disk
+FROM golang:1.21-alpine AS qemuimg2disk
 COPY . /src
 WORKDIR /src/qemuimg2disk
 RUN go mod tidy
 RUN go build -o qemuimg2disk .
 
 # Collect all the files we need into a scratch image.
-FROM scratch as collect
+FROM scratch AS collect
 COPY --from=builder /bin/qemu-img /bin/qemu-img
 COPY --from=builder /bin/sh /bin/sh
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt

--- a/rootio/Dockerfile
+++ b/rootio/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build mkfs as an static
-FROM gcc:10.5.0 as mke2fs
+FROM gcc:10.5.0 AS mke2fs
 RUN wget https://mirrors.edge.kernel.org/pub/linux/kernel/people/tytso/e2fsprogs/v1.45.6/e2fsprogs-1.45.6.tar.gz; tar -xvzf ./e2fsprogs-1.45.6.tar.gz
 WORKDIR /e2fsprogs-1.45.6/
 RUN ./configure --enable-static=yes CFLAGS='-g -O2 -static'
@@ -9,7 +9,7 @@ RUN make
 RUN make -C misc mke2fs.static
 
 # build swap as static
-FROM gcc:10.5.0 as swap
+FROM gcc:10.5.0 AS swap
 RUN git clone git://git.kernel.org/pub/scm/utils/util-linux/util-linux.git
 WORKDIR /util-linux/
 RUN apt-get update; apt-get install -y gettext bison autopoint flex
@@ -19,7 +19,7 @@ RUN make LDFLAGS="-all-static" swapon
 RUN make LDFLAGS="-all-static" mkswap
 
 # Build rootio
-FROM golang:1.21-alpine as rootio
+FROM golang:1.21-alpine AS rootio
 RUN apk add --no-cache git ca-certificates gcc linux-headers musl-dev
 COPY . /src
 WORKDIR /src/rootio
@@ -28,7 +28,7 @@ RUN --mount=type=cache,sharing=locked,id=gomod,target=/go/pkg/mod/cache \
     CGO_ENABLED=1 GOOS=linux go build -a -ldflags "-linkmode external -extldflags '-static' -s -w" -o rootio
 
 # build fattools as static
-FROM gcc:10.5.0 as fattools
+FROM gcc:10.5.0 AS fattools
 RUN git clone https://github.com/dosfstools/dosfstools
 WORKDIR /dosfstools/
 RUN ./autogen.sh
@@ -36,7 +36,7 @@ RUN ./configure
 RUN make LDFLAGS="--static"
 
 # build lvm2 as static
-FROM alpine:3.18 as lvm
+FROM alpine:3.18 AS lvm
 RUN apk update && apk add lvm2-static=2.03.21-r3
 
 # Build final image

--- a/slurp/Dockerfile
+++ b/slurp/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.21-alpine as slurp
+FROM golang:1.21-alpine AS slurp
 RUN apk add --no-cache git ca-certificates gcc linux-headers musl-dev
 COPY . /src
 WORKDIR /src/slurp

--- a/syslinux/Dockerfile
+++ b/syslinux/Dockerfile
@@ -1,7 +1,7 @@
 # syntax=docker/dockerfile:1
 
 # Build syslinux as an syslinux3.86
-FROM gcc:10.2.0 as syslinux3.86
+FROM gcc:10.2.0 AS syslinux3.86
 RUN apt-get update -y; apt-get install -y nasm build-essential uuid-dev
 RUN wget https://cdn.kernel.org/pub/linux/utils/boot/syslinux/3.xx/syslinux-3.86.tar.gz; tar -xvzf ./syslinux-3.86.tar.gz
 WORKDIR /syslinux-3.86/libinstaller
@@ -14,7 +14,7 @@ RUN gcc -Wp,-MT,ldlinux_bin.o,-MMD,./.ldlinux_bin.o.d -W -Wall -Wstrict-prototyp
 RUN gcc -s -static -o syslinux syslinux.o syslxmod.o bootsect_bin.o ldlinux_bin.o
 
 # Build syslinux
-FROM golang:1.21-alpine as syslinux
+FROM golang:1.21-alpine AS syslinux
 RUN apk add --no-cache git ca-certificates gcc linux-headers musl-dev
 COPY . /src
 WORKDIR /src/syslinux

--- a/writefile/Dockerfile
+++ b/writefile/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.21-alpine as writefile
+FROM golang:1.21-alpine AS writefile
 RUN apk add --no-cache git ca-certificates gcc musl-dev
 COPY . /src
 WORKDIR /src/writefile


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Docker build is warning about:
"`FromAsCasing: 'as' and 'FROM' keywords' casing do not match`" This resolves the warning.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
