### PR TITLE
Allow custom path for grub.cfg

### DIFF
--- a/kexec/cmd/kexec.go
+++ b/kexec/cmd/kexec.go
@@ -30,6 +30,7 @@ var kexecCmd = &cobra.Command{
 		filesystemType := os.Getenv("FS_TYPE")
 		kernelPath := os.Getenv("KERNEL_PATH")
 		initrdPath := os.Getenv("INITRD_PATH")
+		grubCfgPath := os.Getenv("GRUBCFG_PATH")
 		cmdLine := os.Getenv("CMD_LINE")
 
 		// These two strings contain the updated paths including the mountAction path
@@ -37,6 +38,10 @@ var kexecCmd = &cobra.Command{
 
 		if blockDevice == "" {
 			log.Fatalf("No Block Device speified with Environment Variable [BLOCK_DEVICE]")
+		}
+
+		if grubCfgPath == "" {
+			grubCfgPath = "boot/grub/grub.cfg"
 		}
 
 		// Create the /mountAction mountpoint (no folders exist previously in scratch container)
@@ -55,7 +60,7 @@ var kexecCmd = &cobra.Command{
 		// If we specify no kernelPath then we will fallback to autodetect and ignore the initrd and cmdline that may be passed
 		// by environment variables
 		if kernelPath == "" {
-			grubFile, err := ioutil.ReadFile(fmt.Sprintf("%s/boot/grub/grub.cfg", mountAction))
+			grubFile, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", mountAction, grubCfgPath))
 			if err != nil {
 				log.Fatal(err)
 			}


### PR DESCRIPTION
## Description

Add the ability to specify custom location for grub.cfg

## Why is this needed

Ubuntu 24.04 cloud image mounts the `/boot` partition. The default `/boot/grub/grub.cfg` location is invalid when we mount the partition. The location when there is a `/boot` partition is `grub/grub.cfg`.

Fixes: #142 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
