### PR TITLE
Allow custom path for grub.cfg

### DIFF
--- a/kexec/README.md
+++ b/kexec/README.md
@@ -13,7 +13,8 @@ the kexec action can mount the newly created Operating System and find it's kern
 paths should relate to the paths "inside" the newly provisioned OS along with the `CMD_LINE`
 that will be required to boot the new OS successfully. To discover these things you may need to
 examine the `/boot` folder in the newly written OS and look in the `/boot/grub/grub.cfg` to
-understand the `CMD_LINE`.
+understand the `CMD_LINE`. Sometime `/boot/grub/grub.cfg` exists as `/grub/grub.cfg` on a a
+partition that is mounted as `/boot`. If this happens, use `GRUBCFG_PATH` with `grub/grub.cfg`.
 
 ```yaml
 actions:

--- a/kexec/README.md
+++ b/kexec/README.md
@@ -13,7 +13,7 @@ the kexec action can mount the newly created Operating System and find it's kern
 paths should relate to the paths "inside" the newly provisioned OS along with the `CMD_LINE`
 that will be required to boot the new OS successfully. To discover these things you may need to
 examine the `/boot` folder in the newly written OS and look in the `/boot/grub/grub.cfg` to
-understand the `CMD_LINE`. Sometime `/boot/grub/grub.cfg` exists as `/grub/grub.cfg` on a a
+understand the `CMD_LINE`. Sometimes `/boot/grub/grub.cfg` will exist as `/grub/grub.cfg` on a
 partition that is mounted as `/boot`. If this happens, use `GRUBCFG_PATH` with `grub/grub.cfg`.
 
 ```yaml

--- a/kexec/cmd/kexec.go
+++ b/kexec/cmd/kexec.go
@@ -31,12 +31,17 @@ var kexecCmd = &cobra.Command{
 		kernelPath := os.Getenv("KERNEL_PATH")
 		initrdPath := os.Getenv("INITRD_PATH")
 		cmdLine := os.Getenv("CMD_LINE")
+		grubCfgPath := os.Getenv("GRUBCFG_PATH")		
 
 		// These two strings contain the updated paths including the mountAction path
 		var kernelMountPath, initrdMountPath string
 
 		if blockDevice == "" {
 			log.Fatalf("No Block Device speified with Environment Variable [BLOCK_DEVICE]")
+		}
+
+		if grubCfgPath == "" {
+			grubCfgPath = "boot/grub/grub.cfg"
 		}
 
 		// Create the /mountAction mountpoint (no folders exist previously in scratch container)
@@ -55,13 +60,13 @@ var kexecCmd = &cobra.Command{
 		// If we specify no kernelPath then we will fallback to autodetect and ignore the initrd and cmdline that may be passed
 		// by environment variables
 		if kernelPath == "" {
-			grubFile, err := ioutil.ReadFile(fmt.Sprintf("%s/boot/grub/grub.cfg", mountAction))
+			grubFile, err := ioutil.ReadFile(fmt.Sprintf("%s/%s", mountAction, grubCfgPath))
 			if err != nil {
 				log.Fatal(err)
 			}
 			bootConfig := grub.GetDefaultConfig(string(grubFile))
 			if bootConfig == nil {
-				log.Fatal("No Kernel configuration passed in [KERNEL_PATH] and unable to parse [/boot/grub/grub.conf]")
+				log.Fatalf("No Kernel configuration passed in [KERNEL_PATH] and unable to parse [/%s]", grubCfgPath)
 			}
 			log.Infof("Loaded boot config: %#v", bootConfig)
 			kernelMountPath = filepath.Join(mountAction, bootConfig.Kernel)


### PR DESCRIPTION
## Description

Add the ability to specify custom location for `grub.cfg`.

## Why is this needed

Ubuntu 24.04 cloud image mounts the `/boot` partition. The default `/boot/grub/grub.cfg` location is invalid when we mount the partition. The location when there is a `/boot` partition is `grub/grub.cfg`.

Fixes: #142 

## How Has This Been Tested?
- Tested on code vagrant with libvirt from https://github.com/tinkerbell/playground/blob/main/stack/docs/quickstarts/VAGRANTLVIRT.md
- Test case 1 - Drop-in change with `jammy`. No `GRUBCFG_PATH`. I was able to ssh into `tink@192.168.56.43`.
- Test case 2 - Drop-in change with `noble`. No `GRUBCFG_PATH`. I was NOT able to ssh into `tink@192.168.56.43`. Expected to fail as `noble` uses a `/boot` partition.
- Test case 3 - Drop-in change with `noble`. The value for `GRUBCFG_PATH` was set to `grub/grub.cfg`. The value for `BLOCK_DEVICE` was set to `{{ formatPartition ( index .Hardware.Disks 0 ) 16 }}`. I was able to ssh into `tink@192.168.56.43`.

## How are existing users impacted? What migration steps/scripts do we need?
It uses the default value of `boot/grub/grub.cfg` for `GRUBCFG_PATH`  if not specified. Existing users are not impacted.


## Checklist:

I have:

- [X] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade

More info on Ubuntu 24.04 cloud image partition - https://bugs.launchpad.net/cloud-images/+bug/2072929
