### PR TITLE
Update cexec

### DIFF
--- a/cexec/main.go
+++ b/cexec/main.go
@@ -225,21 +225,24 @@ func chroot(path string) (func() error, error) {
 
 // mountSpecialDirs ensures that /dev /proc /sys /etc/resolv.conf exist in the chroot.
 func (s settings) mountSpecialDirs(path string) error {
+	if path == "" {
+		return errors.New("mount path cannot be empty")
+	}
 	// Mount dev
 	dev := filepath.Join(path, "dev")
-	if err := syscall.Mount("none", dev, "devtmpfs", syscall.MS_RDONLY, ""); err != nil {
+	if err := syscall.Mount("/dev", dev, "", syscall.MS_BIND, ""); err != nil {
 		return fmt.Errorf("couldn't mount /dev to %v: %w", dev, err)
 	}
 
 	// Mount proc
 	proc := filepath.Join(path, "proc")
-	if err := syscall.Mount("none", proc, "proc", syscall.MS_RDONLY, ""); err != nil {
+	if err := syscall.Mount("/proc", proc, "", syscall.MS_BIND, ""); err != nil {
 		return fmt.Errorf("couldn't mount /proc to %v: %w", proc, err)
 	}
 
 	// Mount sys
 	sys := filepath.Join(path, "sys")
-	if err := syscall.Mount("none", sys, "sysfs", syscall.MS_RDONLY, ""); err != nil {
+	if err := syscall.Mount("/sys", sys, "", syscall.MS_BIND, ""); err != nil {
 		return fmt.Errorf("couldn't mount /sys to %v: %w", sys, err)
 	}
 


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
Upgrade to Go 1.24. Use structured logging. Unmount disk device after use. 

Bind mount existing sources into chroot. Instead of creating new mounts from special filesystems for the chroot, we bind mount the existing locations for /dev, /sys, and/proc.

Creating a new mount point using devtmpfs is not recommended as it can cause issues and conflicts with /dev. Especially when we created the devtmpfs mount point as read only. This caused the host system's /dev to change to read only as well.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
